### PR TITLE
Changelog panel rework

### DIFF
--- a/tabs/landing.css
+++ b/tabs/landing.css
@@ -5,11 +5,14 @@
 
 .tab-landing {
 	min-height: 100%;
+	overflow: hidden;
 }
 
 .tab-landing .content_wrapper {
 	padding: 0;
 	min-height: 100%;
+	height: 100%;
+	overflow-y: auto;
 }
 
 .tab-landing .content_top {
@@ -153,91 +156,77 @@
 
 /* changelog block */
 
-#changelog_bt {
-	height: 84px;
-	width:30px;
-	background-color:green;
-	margin-left:-30px;
-	margin-top:30px;
-	position:fixed;
-	border-top-left-radius:10px;
-	border-bottom-left-radius:10px;
-}
-
-#changelog_button  {
-	display:block;
-	color:white;
-	height:30px;
-	width:100px;
-	transform:rotate(270deg);
-	transform-origin: left top 0;
-  margin-left:6px;
-  margin-top:90px;
-	text-align: center;
-}
-
-.changelog_wrapper {
-	right:0px;
-	height:100%;
-  position:absolute;
-}
-
-.changelog {
-	height:100%;
-	right:0px;
-	width:0px;
-	position:absolute;
-	overflow-y: scroll;
-	background-color:white;
-	border-left: 3px solid green;
-}
-
-.changelog .title {
-  line-height: 20px;
-	text-align:left;
-	padding-left:20px;
-	font-weight: bold;
-	color: #56AC1D;
-	text-transform:uppercase;
-	margin-top: 10px;
-}
-
-.changelog .changewrapper {
+#changelog {
+	width: 250px;
 	height: 100%;
-  padding: 20px;
-  overflow-y: hidden;
-  overflow-x: hidden;
-  -webkit-user-select: text;
-	opacity:0;
+  position: fixed;
+  right: -245px;
+  top: 0px;
 }
 
-.changelog .changewrapper.active {
-	overflow-y: scroll;
-  opacity:0;
+#changelog .wrapper {
+	height: 100%;
+	padding: 0 20px;
+  border-left: 5px solid green;
+  overflow-y: auto;
+	display: none;
 }
 
-.changelog .changewrapper span {
-  font-weight: bold;
-	line-height:22px;
+#changelog .button {
+	transform: rotate(270deg);
+	top: 50px;
+	right: 211px;
+	position: absolute;
+  background: white;
+  border: 5px solid green;
+  border-radius: 10px 10px 0 0;
+  border-bottom: none;
 }
 
-.changelog .changewrapper ul  {
-	margin-bottom:10px;
+#changelog .button a {
+	display: block;
+  padding: 5px 10px;
+  width: 70px;
+  text-align: center;
+}
+
+#changelog .title {
+	margin: 20px 0;
+  font-size: 16px;
+}
+
+#content.log_open #changelog {
+  right: 0px;
+	background: white;
+}
+#content.log_open #changelog .wrapper {
+	display: block;
+}
+
+
+/* changelog content */
+
+#changelog .log  {
 	line-height:17px;
 }
 
-.changelog .changewrapper ul span {
-  font-weight: bold;
+
+#changelog .log span {
+	display: block;
+	font-weight: bold;
+	padding-bottom: 5px;
+	border-bottom:1px solid #ddd;
 }
 
-.changelog .changewrapper li {
+#changelog .log ul  {
+	margin: 5px 0 20px 10px;
+}
+
+#changelog .log li {
   font-weight: normal;
-	margin-left: 0px;
-	border-top:1px solid #eee;
-	padding-top:5px;
-	padding-bottom:5px;
+	margin-bottom:5px;
 }
 
-.changelog .changewrapper p {
+#changelog .log p {
   margin-bottom: 20px;
 }

--- a/tabs/landing.html
+++ b/tabs/landing.html
@@ -1,14 +1,5 @@
 <div class="tab-landing">
    <div class="content_wrapper">
-     <div class="changelog_wrapper">
-        <div class="changelog configurator">
-           <div id="changelog_bt"><a id="changelog_button" href="#">Changelog</a></div>
-           <div class="title" i18n="defaultChangelogHead"></div>
-           <div class="changewrapper">
-              <!-- changelog content will be loaded here -->
-           </div>
-        </div>
-     </div>
       <div class="content_top">
         <div class="logowrapper" align="center">
           <span>Welcome to</span><br>
@@ -17,17 +8,6 @@
         </div>
       </div>
       <div class="content_mid">
-        <!--div class="texts">
-          <h2 class="mid_head">Hardware</h2>
-          <div i18n="defaultWelcomeText"></div>
-          <h2 i18n="defaultContributingHead" class="mid_head"></h2>
-          <div i18n="defaultContributingText"></div>
-          <h2 i18n="defaultDonateHead" class="mid_head"></h2>
-          <div i18n="defaultDonateText"></div>
-          <div class="donate">
-            <a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=TSQKVT6UYKGL6" target="_blank" title="Donate"><img src="./images/btn-donate.png" alt="Paypal" height="30" /></a></li>
-          </div>
-        </div-->
          <div class="column third_left text1">
            <div class="wrap">
              <h2>Hardware</h2>
@@ -65,6 +45,14 @@
             </ul>
          </div>
       </div>
-
+   </div>
+   <div id="changelog">
+      <div class="button"><a id="changelog_toggle" href="#">Changelog</a></div>
+      <div class="wrapper">
+         <div class="title" i18n="defaultChangelogHead"></div>
+         <div class="log">
+            <!-- changelog content will be loaded here -->
+         </div>
+      </div>
    </div>
 </div>

--- a/tabs/landing.js
+++ b/tabs/landing.js
@@ -14,39 +14,33 @@ TABS.landing.initialize = function (callback) {
         localize();
 
         // load changelog content
-        $('div.changelog.configurator .changewrapper').load('./changelog.html');
+        $('#changelog .log').load('./changelog.html');
 
         $('div.welcome a, div.sponsors a').click(function () {
             googleAnalytics.sendEvent('ExternalUrls', 'Click', $(this).prop('href'));
         });
-        
 
-/** changelog trigger **/
-$("#changelog_button").on('click', function() {
-    var state = $(this).data('state2');
-    if ( state ) {
-        $(".changelog").animate({width: 0}, 200);
-	    $(".changewrapper").animate({opacity: 0}, 500);
-		$(".changewrapper").removeClass('active');
-
-        state = false;
-    }else{
-        $(".changelog").animate({width: 220}, 200);
-        $(".changewrapper").animate({opacity: 1}, 500);
-        $(".changewrapper").addClass('active');
-
-        state = true;
-    }
-    $(this).text(state ? 'Close' : 'Changelog');
-    $(this).data('state2', state);
-    
-});
-
-
-
+        /** changelog trigger **/
+        $("#changelog_toggle").on('click', function() {
+            var state = $(this).data('state2');
+            if (state) {
+                $("#changelog").animate({right: -245}, 200, function () {
+                    $("#content").removeClass('log_open');
+                    });
+                state = false;
+            } else {
+                $("#changelog").animate({right: 0}, 200);
+                $("#content").addClass('log_open');
+                state = true;
+            }
+            $(this).text(state ? 'Close' : 'Changelog');
+            $(this).data('state2', state);
+        });
 
         if (callback) callback();
+
     });
+
 };
 
 TABS.landing.cleanup = function (callback) {


### PR DESCRIPTION
I have done more work on Changelog drawer on landing view as I was not happy with the end result of previous merge. Still not perfect but I think it's better. The main thing updated is the scrollable area logic on the main tab so the the changelog panel remains separate from the main tab scrolling. To do it properly we would need more work on entire application layout styles (which is a bit of mess right now), but I think it is not worthwhile to do at this stage. So I scoped my changes with the rework of changelog panel HTML, CSS and JS.